### PR TITLE
Add C# wrapper around Tween Animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,39 @@ To use TweenAnimation with a TweenNode, simply put it in the `animation` propert
 
 The `root_node` property is the Node relative to the TweenNode that will be used by the animation. All animation Tweeners that refer to objects will use that node as a base.
 
-To use TweenAnimation in code, load the animation and call `apply_to_tween()` method.
+### GDScript
+
+To use TweenAnimation in GDScript, load the animation and call `apply_to_tween()` method.
 
 ```GDScript
 var tween = create_tween()
 var animation = load("res://tween_animation.tres")
 animation.apply_to_tween(tween, self)
 ```
-
 The method takes a Tween to which you want to apply the animation and a Node that will be root of the animation.
+
+### C#
+To use TweenAnimation in C#, create a TweenAnimationWrapper resource and link it your TweenAnimation resource.
+You can then export and link the TweenAnimationWrapper as you would any resource in C#.
+
+Then you can just call `Setup()` to create a Tween and setup it with the linked TweenAnimation.
+The method takes the root node you want the Tween to apply to and a bool to bind the Tween to your node.
+```C#
+public partial class YourNode : Node
+{
+   [Export] public TweenAnimationWrapper YourAnimation { get; set; }
+ 
+   public void StartTweenAnimation()
+   {
+       if (YourAnimation != null)
+       {
+           Tween myTween = YourAnimation.Setup(this, true);
+           // Do whatever you want with the tween as usual
+       }
+   }
+}
+```
+
 
 ## TweenAnimation editor ("Tweens")
 

--- a/addons/TweenSuite/TweenAnimationWrapper.cs
+++ b/addons/TweenSuite/TweenAnimationWrapper.cs
@@ -40,7 +40,7 @@ public partial class TweenAnimationWrapper : Resource
     /// </summary>
     public Tween Setup(Node rootNode, bool bindToNode = false)
     {
-        if (AnimationResource != null && rootNode != null)
+        if (AnimationResource != null && rootNode != null && rootNode.IsInsideTree())
         {
             Tween tween = rootNode.GetTree().CreateTween();
             if (bindToNode)

--- a/addons/TweenSuite/TweenAnimationWrapper.cs
+++ b/addons/TweenSuite/TweenAnimationWrapper.cs
@@ -1,0 +1,70 @@
+﻿using Godot;
+
+namespace Godot.TweenSuite;
+
+/// <summary>
+/// <para>TweenAnimationWrapper is a <see cref="Godot.Resource"/> that serves as bridge between a GDScript TweenSuite's TweenAnimation resource and your C# code. Useful to start a data driven <see cref="Godot.Tween"/> directly in your code.</para>
+/// <para>You only have to call <c>@TweenAnimationWrapper.Setup(rootNode)</c> to create a <see cref="Godot.Tween"/> and setup any <see cref="Godot.Tweener"/> defined in the linked TweenAnimation.</para>
+/// </summary>
+[GlobalClass]
+public partial class TweenAnimationWrapper : Resource
+{
+    /// <summary>
+    /// <para>Link to your GDScript TweenSuite's TweenAnimation resource file.</para>
+    /// </summary>
+    [Export(PropertyHint.ResourceType, "TweenAnimation")]
+    public Resource AnimationResource{ get; set; }
+
+    // Name of the "apply_to_tween" method in the GDScript
+    private readonly StringName _applyToTweenMethod = new StringName("apply_to_tween");
+    
+    /// <summary>
+    /// <para>Creates a <see cref="Godot.Tween"/> and setups it with your linked TweenAnimation.</para>
+    /// <para> <b>rootNode</b> is the root <see cref="Godot.Node"/> you want to tween.</para>
+    /// <para> <b>bindToNode</b> will bind your Tween to your Node, killing it if your node exit the tree or is freed.</para>
+    /// <para><code>
+    /// public partial class YourNode : Node
+    /// {
+    ///    [Export] public TweenAnimationWrapper YourAnimation { get; set; }
+    /// 
+    ///     public void StartTweenAnimation()
+    ///     {
+    ///         if (YourAnimation != null)
+    ///         {
+    ///             Tween myTween = YourAnimation.Setup(this, true);
+    ///             // Do whatever you want with the tween as usual
+    ///         }
+    ///     }
+    /// }
+    /// </code></para>
+    /// </summary>
+    public Tween Setup(Node rootNode, bool bindToNode = false)
+    {
+        if (AnimationResource != null && rootNode != null)
+        {
+            Tween tween = rootNode.GetTree().CreateTween();
+            if (bindToNode)
+            {
+                tween.BindNode(rootNode);
+            }
+            AnimationResource.Call(_applyToTweenMethod, tween, rootNode);
+            return tween;
+        }
+        return null;
+    }
+    
+    /// <summary>
+    /// <para>Setups a <see cref="Godot.Tween"/> on a <see cref="Godot.Node"/> with your linked TweenAnimation.</para>
+    /// <para> <b>rootNode</b> is the root Node you want to tween.</para>
+    /// <para> <b>tween</b> the tween you want to setup with your TweenAnimation.</para>
+    /// </summary>
+    public bool ApplyToTween(Node rootNode, Tween tween)
+    {
+        if (AnimationResource != null && rootNode != null && tween != null)
+        {
+            AnimationResource.Call(_applyToTweenMethod, tween, rootNode);
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Hi !
I discovered your awesome plugin, but unfortunatly was not able to use TweenAnimation easily in my C# code as it's GDScript only.
For various reason using the TweenNode was not ideal for me as I'm querying the animation based on a bunch of factors, so it's easier to fetch the animation in a custom resource, and then start the right one.

To be able to do that, I've made this wrapper around TweenAnimation.

It's really simple, just create a TweenAnimationWrapper resource and link it a TweenAnimation resource.

Then in code, just call Setup to get a tween initialized with your tween animation, and then you can manipulate it like any other tween.

I'm a bit torn on the name as it doesn't explicitely say it's a bridge between GDScript and C# so maybe TweenAnimationCSharp or TweenAnimationCSharpBridge would be better.

Also please note that while I have experience making games for a living as a C++ engineer, I'm a complete godot noob, having only started a prototype 2 weeks ago ^^, so there might be way betters ways to bridge GDScript and C#, i just couldn't find any barring other plugins.

Have a nice day !