### PR TITLE
Add parameters to TweenAnimation and a way to access them in the editor via "%parameter_name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,39 @@ To use TweenAnimation with a TweenNode, simply put it in the `animation` propert
 
 The `root_node` property is the Node relative to the TweenNode that will be used by the animation. All animation Tweeners that refer to objects will use that node as a base.
 
-To use TweenAnimation in code, load the animation and call `apply_to_tween()` method.
+### GDScript
+
+To use TweenAnimation in GDScript, load the animation and call `apply_to_tween()` method.
 
 ```GDScript
 var tween = create_tween()
 var animation = load("res://tween_animation.tres")
 animation.apply_to_tween(tween, self)
 ```
-
 The method takes a Tween to which you want to apply the animation and a Node that will be root of the animation.
+
+### C#
+To use TweenAnimation in C#, create a TweenAnimationWrapper resource and link it your TweenAnimation resource.
+You can then export and link the TweenAnimationWrapper as you would any resource in C#.
+
+Then you can just call `Setup()` to create a Tween and setup it with the linked TweenAnimation.
+The method takes the root node you want the Tween to apply to and a bool to bind the Tween to your node.
+```C#
+public partial class YourNode : Node
+{
+   [Export] public TweenAnimationWrapper YourAnimation { get; set; }
+ 
+   public void StartTweenAnimation()
+   {
+       if (YourAnimation != null)
+       {
+           Tween myTween = YourAnimation.Setup(this, true);
+           // Do whatever you want with the tween as usual
+       }
+   }
+}
+```
+
 
 ## TweenAnimation editor ("Tweens")
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ animation.apply_to_tween(tween, self)
 ```
 The method takes a Tween to which you want to apply the animation and a Node that will be root of the animation.
 
+#### Parameters
+You can also add/remove parameters to be able to target them in the editor with a specific syntax described in the "Value fields" section below.
+Useful to be able to assign custom values per animation instead of having to create properties or meta data
+Make sure to set the parameters before calling `apply_to_tween()`
+
+Methods are : 
+
+`set_parameter(StringName name, Variant value)` to set a parameter for the given name
+
+`remove_parameter(StringName name)` to remove the parameter for the given name
+
+`remove_all_parameters()` to remove all set parameters
+
+`get_parameters(StringName name) -> Variant` to access a parameter value for the given name
+
+```GDScript
+var tween = create_tween()
+var animation = load("res://tween_animation.tres")
+animation.set_parameter("MyParameterName", myValue)
+animation.apply_to_tween(tween, self)
+animation.remove_all_parameters();
+```
+
 ### C#
 To use TweenAnimation in C#, create a TweenAnimationWrapper resource and link it your TweenAnimation resource.
 You can then export and link the TweenAnimationWrapper as you would any resource in C#.
@@ -85,6 +108,38 @@ public partial class YourNode : Node
    {
        if (YourAnimation != null)
        {
+           Tween myTween = YourAnimation.Setup(this, true);
+           // Do whatever you want with the tween as usual
+       }
+   }
+}
+```
+
+#### Parameters
+You can also add/remove parameters to be able to target them in the editor with a specific syntax described in the "Value fields" section below.
+Useful to be able to assign custom values per animation instead of having to create properties or meta data.
+Make sure to set the parameters before calling `Setup()`
+
+Methods are :
+
+`SetParameter(StringName name, Variant value)` to set a parameter for the given name
+
+`RemoveParameter(StringName name)` to remove the parameter for the given name
+
+`RemoveAllParameters()` to remove all set parameters
+
+`Variant GetParameters(StringName name)` to access a parameter value for the given name
+
+```C#
+public partial class YourNode : Node
+{
+   [Export] public TweenAnimationWrapper YourAnimation { get; set; }
+ 
+   public void StartTweenAnimation()
+   {
+       if (YourAnimation != null)
+       {
+           YourAnimation.SetParameter("ParameterName", myValue);
            Tween myTween = YourAnimation.Setup(this, true);
            // Do whatever you want with the tween as usual
        }
@@ -143,7 +198,7 @@ If the value is valid, its tooltip will display the result of evaluation.
 
 In general, this just means that you need to write your value by hand. There is a basic validation, but it doesn't check whether the value type matches the object's property etc.
 
-You can also access the target object's properties or metadata using special syntax. Using `@property_name` will access object's properties and `$metadata_name` will access object's metadata. For example `$target_color` will do `get_meta("target_color")` on the target object. Variables are evaluated when the animation is first applied and don't support expressions (you can only use them as-is).
+You can also access the target object's properties or metadata using special syntax. Using `@property_name` will access object's properties , `$metadata_name` will access object's metadata and `%parameter_name` will access the animation parameters. For example `$target_color` will do `get_meta("target_color")` on the target object. Variables are evaluated when the animation is first applied and don't support expressions (you can only use them as-is).
 
 ![](Media/ValueMetadata.png)
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ The method takes a Tween to which you want to apply the animation and a Node tha
 
 #### Parameters
 You can also add/remove parameters to be able to target them in the editor with a specific syntax described in the "Value fields" section below.
-Useful to be able to assign custom values per animation instead of having to create properties or meta data
+Useful to be able to assign custom values per animation instead of having to create properties or meta data.
+Be aware that resources are shared by default so parameters will apply to all instances if you don't duplicate them.
 Make sure to set the parameters before calling `apply_to_tween()`
 
 Methods are : 
@@ -116,36 +117,7 @@ public partial class YourNode : Node
 ```
 
 #### Parameters
-You can also add/remove parameters to be able to target them in the editor with a specific syntax described in the "Value fields" section below.
-Useful to be able to assign custom values per animation instead of having to create properties or meta data.
-Make sure to set the parameters before calling `Setup()`
-
-Methods are :
-
-`SetParameter(StringName name, Variant value)` to set a parameter for the given name
-
-`RemoveParameter(StringName name)` to remove the parameter for the given name
-
-`RemoveAllParameters()` to remove all set parameters
-
-`Variant GetParameters(StringName name)` to access a parameter value for the given name
-
-```C#
-public partial class YourNode : Node
-{
-   [Export] public TweenAnimationWrapper YourAnimation { get; set; }
- 
-   public void StartTweenAnimation()
-   {
-       if (YourAnimation != null)
-       {
-           YourAnimation.SetParameter("ParameterName", myValue);
-           Tween myTween = YourAnimation.Setup(this, true);
-           // Do whatever you want with the tween as usual
-       }
-   }
-}
-```
+You can also use parameters in C# (see Parameter in GDScript just above), all functions are duplicated in the TweenAnimationWrapper.
 
 
 ## TweenAnimation editor ("Tweens")

--- a/addons/TweenSuite/TweenAnimation.gd
+++ b/addons/TweenSuite/TweenAnimation.gd
@@ -7,7 +7,7 @@ extends Resource
 class_name TweenAnimation
 
 var steps: Array
-var parameters: Dictionary;
+var parameters: Dictionary
 
 ## Applies this animation to the given [Tween]. The [param root] is the base node for animation paths. Called automatically when using [TweenNode].
 ## [codeblock]
@@ -48,7 +48,7 @@ func set_parameter(name: StringName, value: Variant):
 func remove_parameter(name: StringName):
 	parameters.erase(name)
 
-## Removes all parameters
+## Removes all parameters.
 ## [codeblock]
 ## var tween = create_tween()
 ## var animation = load("res://tween_animation.tres")
@@ -60,10 +60,7 @@ func remove_parameter(name: StringName):
 func remove_all_parameters():
 	parameters.clear()
 
-## Return the value of a parameter
-## [codeblock]
-## var value = animation.get_parameter("MyName")
-## [/codeblock]
+## Return the value of a parameter.
 func get_parameter(name: StringName) -> Variant:
 	return parameters[name];
 
@@ -144,7 +141,7 @@ class TweenerAnimator:
 		for property in data:
 			set(property, data[property])
 	
-	func apply_to_tween(tween: Tween, root: Node, animation:TweenAnimation):
+	func apply_to_tween(tween: Tween, root: Node, animation: TweenAnimation):
 		pass
 	
 	static func get_target_object(root: Node, path: NodePath) -> Object:
@@ -170,7 +167,7 @@ class TweenerAnimator:
 		tweener.apply_dictionary(data)
 		return tweener
 	
-	static func evaluate(data: Variant, object: Object, animation:TweenAnimation ) -> Variant:
+	static func evaluate(data: Variant, object: Object, animation: TweenAnimation ) -> Variant:
 		if data is String:
 			if data.begins_with("@"):
 				return object.get(data.substr(1))
@@ -199,7 +196,7 @@ class PropertyTweenerAnimator extends TweenerAnimator:
 	func get_name() -> String:
 		return "Property Tweener"
 	
-	func apply_to_tween(tween: Tween, root: Node, animation:TweenAnimation):
+	func apply_to_tween(tween: Tween, root: Node, animation: TweenAnimation):
 		var object := TweenerAnimator.get_target_object(root, target)
 		
 		var final_final_value: Variant = TweenerAnimator.evaluate(final_value, object, animation)
@@ -227,7 +224,7 @@ class IntervalTweenerAnimator extends TweenerAnimator:
 	func get_name() -> String:
 		return "Interval Tweener"
 	
-	func apply_to_tween(tween: Tween, root: Node, animation:TweenAnimation):
+	func apply_to_tween(tween: Tween, root: Node, animation: TweenAnimation):
 		tween.tween_interval(time)
 
 class CallbackTweenerAnimator extends TweenerAnimator:
@@ -241,7 +238,7 @@ class CallbackTweenerAnimator extends TweenerAnimator:
 	func get_name() -> String:
 		return "Callback Tweener"
 	
-	func apply_to_tween(tween: Tween, root: Node, animation:TweenAnimation):
+	func apply_to_tween(tween: Tween, root: Node, animation: TweenAnimation):
 		tween.tween_callback(Callable(TweenerAnimator.get_target_object(root, target), method)).set_delay(delay)
 
 class MethodTweenerAnimator extends TweenerAnimator:
@@ -260,7 +257,7 @@ class MethodTweenerAnimator extends TweenerAnimator:
 	func get_name() -> String:
 		return "Method Tweener"
 	
-	func apply_to_tween(tween: Tween, root: Node, animation:TweenAnimation):
+	func apply_to_tween(tween: Tween, root: Node, animation: TweenAnimation):
 		var target := TweenerAnimator.get_target_object(root, target)
 		var final_from := TweenerAnimator.evaluate(from, target, animation)
 		var final_to := TweenerAnimator.evaluate(to, target, animation)

--- a/addons/TweenSuite/TweenAnimationEditor/EditorComponents/TweenerEditor.tscn
+++ b/addons/TweenSuite/TweenAnimationEditor/EditorComponents/TweenerEditor.tscn
@@ -51,6 +51,7 @@ icon_name = &"Remove"
 
 [node name="PropertyTweener" type="GridContainer" parent="VBoxContainer"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 columns = 2
 

--- a/addons/TweenSuite/TweenAnimationEditor/GUIComponents/ExpressionEdit.gd
+++ b/addons/TweenSuite/TweenAnimationEditor/GUIComponents/ExpressionEdit.gd
@@ -13,22 +13,25 @@ var result: Variant:
 			tooltip_text = """<null>
 Possible input:
 Variant constructor (Color(1, 0, 0), "string", Vector2(), etc.)
-@property name
-$metadata name
+@property name on the Object
+$metadata name on the Object
+%parameter name on the TweenAnimation
 """
 		else:
 			if not sync:
 				text = var_to_str(result)
 				if result is String:
-					if result.begins_with("@") or result.begins_with("$"):
+					if result.begins_with("@") or result.begins_with("$") or result.begins_with("%"):
 						text = result
 			
 			tooltip_text = str(result)
 			if result is String:
 				if result.begins_with("@"):
-					tooltip_text = "Property: \"%s\"" % result.substr(1)
+					tooltip_text = "Object Property: \"%s\"" % result.substr(1)
 				elif result.begins_with("$"):
-					tooltip_text = "Metadata: \"%s\"" % result.substr(1)
+					tooltip_text = "Object Metadata: \"%s\"" % result.substr(1)
+				elif result.begins_with("%"):
+					tooltip_text = "TweenAnimation Parameter: \"%s\"" % result.substr(1)
 
 func _ready() -> void:
 	var timer := Timer.new()
@@ -43,7 +46,7 @@ func evaluate():
 	var value: Variant
 	if text.is_empty():
 		value = null
-	elif text.begins_with("@") or text.begins_with("$"):
+	elif text.begins_with("@") or text.begins_with("$") or text.begins_with("%"):
 		value = text
 	else:
 		var expression := Expression.new()

--- a/addons/TweenSuite/TweenAnimationWrapper.cs
+++ b/addons/TweenSuite/TweenAnimationWrapper.cs
@@ -40,7 +40,7 @@ public partial class TweenAnimationWrapper : Resource
     /// </summary>
     public Tween Setup(Node rootNode, bool bindToNode = false)
     {
-        if (AnimationResource != null && rootNode != null)
+        if (AnimationResource != null && rootNode != null && rootNode.IsInsideTree())
         {
             Tween tween = rootNode.GetTree().CreateTween();
             if (bindToNode)

--- a/addons/TweenSuite/TweenAnimationWrapper.cs
+++ b/addons/TweenSuite/TweenAnimationWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿using System;
+using Godot;
 
 namespace Godot.TweenSuite;
 
@@ -15,8 +16,12 @@ public partial class TweenAnimationWrapper : Resource
     [Export(PropertyHint.ResourceType, "TweenAnimation")]
     public Resource AnimationResource{ get; set; }
 
-    // Name of the "apply_to_tween" method in the GDScript
+    // Method bridge
     private readonly StringName _applyToTweenMethod = new StringName("apply_to_tween");
+    private readonly StringName _setParameterMethod = new StringName("set_parameter");
+    private readonly StringName _removeParameterMethod = new StringName("remove_parameter");
+    private readonly StringName _removeAllParametersMethod = new StringName("remove_all_parameters");
+    private readonly StringName _getParameterMethod = new StringName("get_parameter");
     
     /// <summary>
     /// <para>Creates a <see cref="Godot.Tween"/> and setups it with your linked TweenAnimation.</para>
@@ -66,5 +71,60 @@ public partial class TweenAnimationWrapper : Resource
             return true;
         }
         return false;
+    }
+    
+    /// <summary>
+    /// <para>Sets a runtime parameter on the animation. Used for code defined values.</para>
+    /// <para>Setting a null value will remove the parameter, equivalent to RemoveParameter().</para>
+    /// <para> <b>name</b> is the name of the parameter. Can be accessed in the editor via "%name" in the variant fields.</para>
+    /// <para> <b>value</b> your custom value.</para>
+    /// </summary>
+    public bool SetParameter(StringName name, Variant value)
+    {
+        if (AnimationResource != null && name != null)
+        {
+            AnimationResource.Call(_setParameterMethod, name, value);
+            return true;
+        }
+        return false;
+    }
+    
+    /// <summary>
+    /// <para>Removes a runtime parameter on the animation.</para>
+    /// <para> <b>name</b> is the name of the parameter.</para>
+    /// </summary>
+    public bool RemoveParameter(StringName name)
+    {
+        if (AnimationResource != null && name != null)
+        {
+            AnimationResource.Call(_removeParameterMethod, name);
+            return true;
+        }
+        return false;
+    }
+    
+    /// <summary>
+    /// <para>Removes all parameters on the animation.</para>
+    /// </summary>
+    public bool RemoveAllParameters()
+    {
+        if (AnimationResource != null)
+        {
+            AnimationResource.Call(_removeAllParametersMethod);
+            return true;
+        }
+        return false;
+    }
+    
+    /// <summary>
+    /// <para>Removes all parameters on the animation.</para>
+    /// </summary>
+    public Variant GetParameter(StringName name)
+    {
+        if (AnimationResource != null)
+        {
+            return AnimationResource.Call(_getParameterMethod, name);
+        }
+        return default;
     }
 }

--- a/addons/TweenSuite/TweenAnimationWrapper.cs
+++ b/addons/TweenSuite/TweenAnimationWrapper.cs
@@ -1,0 +1,70 @@
+﻿using Godot;
+
+namespace Godot.TweenSuite;
+
+/// <summary>
+/// <para>TweenAnimationWrapper is a <see cref="Godot.Resource"/> that serves as bridge between a GDScript TweenSuite's TweenAnimation resource and your C# code. Useful to start a data driven <see cref="Godot.Tween"/> directly in your code.</para>
+/// <para>You only have to call <c>@TweenAnimationWrapper.Setup(rootNode)</c> to create a <see cref="Godot.Tween"/> and setup any <see cref="Godot.Tweener"/> defined in the linked TweenAnimation.</para>
+/// </summary>
+[GlobalClass]
+public partial class TweenAnimationWrapper : Resource
+{
+    /// <summary>
+    /// <para>Link to your GDScript TweenSuite's TweenAnimation resource file.</para>
+    /// </summary>
+    [Export(PropertyHint.ResourceType, "TweenAnimation")]
+    public Resource AnimationResource{ get; set; }
+
+    // Name of the "apply_to_tween" method in the GDScript
+    private readonly StringName _applyToTweenMethod = new StringName("apply_to_tween");
+    
+    /// <summary>
+    /// <para>Creates a <see cref="Godot.Tween"/> and setups it with your linked TweenAnimation.</para>
+    /// <para> <b>rootNode</b> is the root <see cref="Godot.Node"/> you want to tween.</para>
+    /// <para> <b>bindToNode</b> will bind your Tween to your Node, killing it if your node exit the tree or is freed.</para>
+    /// <para><code>
+    /// public partial class YourNode : Node
+    /// {
+    ///    [Export] public TweenAnimationWrapper YourAnimation { get; set; }
+    /// 
+    ///     public void StartTweenAnimation()
+    ///     {
+    ///         if (YourAnimation != null)
+    ///         {
+    ///             Tween myTween = YourAnimation.Setup(this, true);
+    ///             // Do whatever you want with the tween as usual
+    ///         }
+    ///     }
+    /// }
+    /// </code></para>
+    /// </summary>
+    public Tween Setup(Node rootNode, bool bindToNode = false)
+    {
+        if (AnimationResource != null && rootNode != null)
+        {
+            Tween tween = rootNode.GetTree().CreateTween();
+            if (bindToNode)
+            {
+                tween.BindNode(rootNode);
+            }
+            AnimationResource.Call(_applyToTweenMethod, tween, rootNode);
+            return tween;
+        }
+        return null;
+    }
+    
+    /// <summary>
+    /// <para>Setups a <see cref="Godot.Tween"/> on a <see cref="Godot.Node"/> with your linked TweenAnimation.</para>
+    /// <para> <b>rootNode</b> is the root Node you want to tween.</para>
+    /// <para> <b>tween</b> the tween you want to setup with your TweenAnimation.</para>
+    /// </summary>
+    public bool ApplyToTween(Node rootNode, Tween tween)
+    {
+        if (AnimationResource != null && rootNode != null && tween != null)
+        {
+            AnimationResource.Call(_applyToTweenMethod, tween, rootNode);
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
When using lots of TweenAnimation in code with dynamic values to target, it can quickly become cumbersome to use metadata or properties on the node as you have to declare one per dynamic value and make sure two animations that can run in parallel don't use the same one.

To that effect I've added a Dictionary to Tween Animation to be able to set parameters directly on the animation.
It comes with set_parameter, remove_parameter, remove_all_parameters, and get_parameters methods and the parameter can be accessed via the editor by using "%parameter_name" like you would with "$" or "@" for properties or meta data.

This allow to have a more compact code and avoid properties used only for tween targets and it works great with loops.

```
 if (ActivateAnimation != null)
 {
     Vector3 targetPosition = Position;
     foreach(DominoCell cell in _cells)
     {
          targetPosition += Offset;
          ActivateAnimation.SetParameter("Position", targetPosition);
          ActivateAnimation.Setup(cell);
      }
}
```

Used like this : 
![image](https://github.com/user-attachments/assets/7922d91b-b4e8-49d3-b6bf-cbe7c01b7446)


I started by using the TweenAnimation metadata directly but I finally went back and prefered to add the dictionary to separate the two features in case someone wanted to use meta data on the TweenAnimation for other purposes.

I tested all methods with the C# bridge that I also updated, but because it calls the GDScript methods I'm pretty sure it works with GDScript as well.