### PR TITLE
Fix not being able to delete animation steps and deserialization

### DIFF
--- a/addons/TweenSuite/TweenAnimationEditor/EditorComponents/AnimationStep.tscn
+++ b/addons/TweenSuite/TweenAnimationEditor/EditorComponents/AnimationStep.tscn
@@ -78,4 +78,4 @@ popup/item_4/id = 4
 popup/item_5/text = "Await"
 popup/item_5/id = 5
 
-[connection signal="pressed" from="AnimationStep/VBoxContainer/MarginContainer/HBoxContainer/Button" to="AnimationStep" method="delete_me"]
+[connection signal="pressed" from="AnimationStep/VBoxContainer/MarginContainer/HBoxContainer/Button" to="." method="delete_me"]

--- a/addons/TweenSuite/TweenAnimationEditor/GUIComponents/OptionHelper.gd
+++ b/addons/TweenSuite/TweenAnimationEditor/GUIComponents/OptionHelper.gd
@@ -4,3 +4,8 @@ extends OptionButton
 var value: int:
 	get:
 		return get_selected_id()
+	set(r):
+		if r == -1:
+			select(0)
+		else:
+			select(get_item_index(r))


### PR DESCRIPTION
Animation steps were unable to be deleted because the path to the root was wrong, probably a GUI component has been inserted and the path didn't update properly.

The easing and transition values weren't properly deserialized and would revert to `Default` each time the editor is opened.   
This was because `OptionHelper.value` lacked a setter.